### PR TITLE
Fix /etc/localtime wrong on Ubuntu 12.04.2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,10 +18,9 @@ class timezone (
   $hwutc = "true"){
   
 
-  file { "/etc/localtime":
-    # We copy the timezone file into /etc to cater for
-    # situations when /usr is not available
-    source => "file:///usr/share/zoneinfo/$region/$locality",
+  file { '/etc/localtime':
+    ensure => link,
+    target => "/usr/share/zoneinfo/${region}/${locality}",
   }
 
   # Debian and Enterprise Linux have differing ways of recording


### PR DESCRIPTION
Applying this module on Ubuntu 12.04.2 causes the /etc/localtime to
point to wrong destination:
lrwxrwxrwx 1 root root 20 Mar  4 13:38 localtime -> ../posix/Brazil/East

With this fix the file will be linked to (for example):
lrwxrwxrwx 1 root root 37 Mar  4 10:51 localtime -> /usr/share/zoneinfo/America/Sao_Paulo
