### PR TITLE
Fix utc parameter and install packages before creating the /etc/localtime file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 class timezone (
   $region, 
   $locality,
-  $hwutc = 'true'){
+  $hwutc = true){
   
 
   file { '/etc/localtime':


### PR DESCRIPTION
The fix for utc is because on the Gentoo side we don't use true/false and my previous code would always treat it as true, it seems.

The other fix ensures that the package is there _before_ it gets created.

HTH!
