### PR TITLE
Fixed variable access deprecation warnings in ERB templates.

### DIFF
--- a/templates/debian.erb
+++ b/templates/debian.erb
@@ -1,1 +1,1 @@
-<%= region %>/<%= locality %>
+<%= @region %>/<%= @locality %>

--- a/templates/el.erb
+++ b/templates/el.erb
@@ -1,2 +1,2 @@
-ZONE="<%= region %>/<%= locality %>"
-UTC=<%= hwutc %>
+ZONE="<%= @region %>/<%= @locality %>"
+UTC=<%= @hwutc %>

--- a/templates/gentoo.erb
+++ b/templates/gentoo.erb
@@ -4,7 +4,7 @@
 # Greenwich Mean Time).  If that clock is set to the local time, then
 # set CLOCK to "local".  Note that if you dual boot with Windows, then
 # you should set it to "local".
-clock=<%= hwutc ? 'UTC' : 'local' %>
+clock=<%= @hwutc ? 'UTC' : 'local' %>
 
 # If you want the hwclock script to set the system time (software clock)
 # to match the current hardware clock during bootup, leave this

--- a/templates/suse.erb
+++ b/templates/suse.erb
@@ -80,5 +80,5 @@ USE_ADJUST="no"
 # the /etc/localtime file, YaST does that or you will need to do
 # this manually by calling zic -l.
 #
-TIMEZONE="<%= region %>/<%= locality %>"
-DEFAULT_TIMEZONE="<%= region %>/<%= locality %>"
+TIMEZONE="<%= @region %>/<%= @locality %>"
+DEFAULT_TIMEZONE="<%= @region %>/<%= @locality %>"


### PR DESCRIPTION
Access variables in ERB templates as `@variable` instead of `variable` to shut off warnings like:

```
Warning: Variable access via 'region' is deprecated. Use '@region' instead. template[/etc/puppet/environments/production/modules/timezone/templates/debian.erb]:1
```
