### PR TITLE
change metadata field from requirements to dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -65,7 +65,7 @@
       ]
     }
   ],
-  "requirements": [
+  "dependencies": [
     {
       "name": "pe",
       "version_requirement": "3.x"


### PR DESCRIPTION
The `requirements` field in metadata.json causes puppet to issue a `Could not find class` error:

```
[vagrant@centos64 ~]$ cat /etc/redhat-release 
CentOS release 6.4 (Final)

[vagrant@centos64 ~]$ puppet --version
3.2.4

[vagrant@centos64 ~]$ git clone https://github.com/bashtonltd/puppet-timezone
Initialized empty Git repository in /home/vagrant/puppet-timezone/.git/
remote: Counting objects: 108, done.
remote: Total 108 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (108/108), 17.73 KiB, done.
Resolving deltas: 100% (34/34), done.

[vagrant@centos64 ~]$ mkdir modules
[vagrant@centos64 ~]$ ln -s $(pwd)/puppet-timezone modules/timezone

[vagrant@centos64 ~]$ sudo puppet apply --noop --modulepath=$(pwd)/modules modules/timezone/tests/init.pp 
Error: Could not find class timezone for centos64.localdomain on node centos64.localdomain
Error: Could not find class timezone for centos64.localdomain on node centos64.localdomain
```

Changing the `requirements` field to `dependencies` fixes it:

```
[vagrant@centos64 ~]$ sed -i -e 's/requirements/dependencies/' modules/timezone/metadata.json 

[vagrant@centos64 ~]$ sudo puppet apply --noop --modulepath=$(pwd)/modules modules/timezone/tests/init.pp 
Warning: Config file /etc/puppet/hiera.yaml not found, using Hiera defaults
Notice: /Stage[main]/Timezone/File[/etc/sysconfig/clock]/content: current_value {md5}c5daf08a96d4decb4886f54d6a280348, should be {md5}e2ef1ca924ffd45d61ddd0a2cbb7700f (noop)
Notice: Class[Timezone]: Would have triggered 'refresh' from 1 events
Notice: Stage[main]: Would have triggered 'refresh' from 1 events
Notice: Finished catalog run in 0.17 seconds
```


The puppet documentation lists `dependencies` as a required field, not
`requirements`:

https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#fields-in-metadatajson
