### PR TITLE
Add required "dependencies" field to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -81,5 +81,6 @@
       "name": "puppet",
       "version_requirement": ">= 3.1.0"
     }
-  ]
+  ],
+  "dependencies": []
 }


### PR DESCRIPTION
The metadata.json is required to contain field 'dependencies' even when
there are no actual module dependencies. Without this field, Puppet will
fail to recognize any code in the module as it cannot parse the
metadata.json. This will cause the parser to not find the code when
compiling catalogs.

This commit adds the empty 'dependencies' field to the metadata.json.
The metadata.json was confirmed with the `puppet-community/metadata-json-lint` tool.